### PR TITLE
Showing top-n metrics on reporter

### DIFF
--- a/asyncio_inspector/reporter.py
+++ b/asyncio_inspector/reporter.py
@@ -25,6 +25,7 @@ class LoggerReporter(Thread, BaseReporter):
     logger: Logger
     running: bool
     sleep_period: int
+    show_top_n: int
 
     def __init__(self, logger: Logger) -> None:
         super().__init__()
@@ -32,6 +33,13 @@ class LoggerReporter(Thread, BaseReporter):
         self.running = True
         self.sleep_period = 1
         self.daemon = True
+        self.show_top_n = 10
+
+    def _get_line(self, data) -> str:
+        """ "Returns the top-n itens in data as a string"""
+        return " | ".join(
+            f"{k}: {v}" for k, v in data.items()[: self.show_top_n]
+        )
 
     def run(self) -> None:
         while self.running:
@@ -43,9 +51,13 @@ class LoggerReporter(Thread, BaseReporter):
                 if self.stats_tracker.ready_queue is not None
                 else 0
             )
+            fmt = self._get_line
             self.logger.debug(
                 f"Queue size: {ready_queue_size}\n"
-                f"Call counts: {self.stats_tracker.call_counts}"
+                f"Call counts: {fmt(self.stats_tracker.call_counts)}\n"
+                f"Max exec times: {fmt(self.stats_tracker.max_time)}\n"
+                f"Total exec times: {fmt(self.stats_tracker.total_time)}\n"
+                f"Avg exec times: {fmt(self.stats_tracker.avg_time)}"
             )
             time.sleep(self.sleep_period)
 

--- a/asyncio_inspector/stats.py
+++ b/asyncio_inspector/stats.py
@@ -13,11 +13,11 @@ class BaseStatsTracker:
     """"Basic stats tracker""" ""
 
     ready_queue: Optional[ObservableDeque]
-    call_counts: ValueSortedDict[str, int]
-    total_time: ValueSortedDict[str, int]
-    avg_time: ValueSortedDict[str, int]
-    max_time: ValueSortedDict[str, int]
-    min_time: ValueSortedDict[str, int]
+    call_counts: ValueSortedDict
+    total_time: ValueSortedDict
+    avg_time: ValueSortedDict
+    max_time: ValueSortedDict
+    min_time: ValueSortedDict
 
     def __init__(self, ready_queue: ObservableDeque = None) -> None:
         self.ready_queue = ready_queue

--- a/asyncio_inspector/stats.py
+++ b/asyncio_inspector/stats.py
@@ -1,24 +1,31 @@
-from collections import defaultdict
-from typing import Dict, Optional
+from typing import Optional
+
+from sortedcollections import ValueSortedDict
 
 from asyncio_inspector.events import ObservableDeque, ObservableHandle
+
+
+def invert(x):
+    return -x
 
 
 class BaseStatsTracker:
     """"Basic stats tracker""" ""
 
     ready_queue: Optional[ObservableDeque]
-    call_counts: Dict[str, int]
-    total_time: Dict[str, int]
-    max_time: Dict[str, int]
-    min_time: Dict[str, int]
+    call_counts: ValueSortedDict[str, int]
+    total_time: ValueSortedDict[str, int]
+    avg_time: ValueSortedDict[str, int]
+    max_time: ValueSortedDict[str, int]
+    min_time: ValueSortedDict[str, int]
 
     def __init__(self, ready_queue: ObservableDeque = None) -> None:
         self.ready_queue = ready_queue
-        self.call_counts = defaultdict(int)
-        self.total_time = defaultdict(int)
-        self.max_time = defaultdict(int)
-        self.min_time = defaultdict(int)
+        self.call_counts = ValueSortedDict(invert)
+        self.total_time = ValueSortedDict(invert)
+        self.avg_time = ValueSortedDict(invert)
+        self.max_time = ValueSortedDict(invert)
+        self.min_time = ValueSortedDict(invert)
 
     def track_call(
         self,
@@ -27,6 +34,13 @@ class BaseStatsTracker:
         end_timestamp: int,
     ) -> None:
         callback = handle.get_callback()
+        if callback not in self.call_counts:
+            self.call_counts[callback] = 0
+            self.total_time[callback] = 0
+            self.avg_time[callback] = 0
+            self.max_time[callback] = 0
+            self.min_time[callback] = 0
+
         self.call_counts[callback] += 1
         elapsed_time = end_timestamp - start_timestamp
         self.total_time[callback] += elapsed_time
@@ -34,3 +48,6 @@ class BaseStatsTracker:
             self.max_time[callback] = elapsed_time
         if elapsed_time < self.min_time[callback]:
             self.min_time[callback] = elapsed_time
+        self.avg_time[callback] = (
+            self.total_time[callback] / self.call_counts[callback]
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sortedcollections==2.4.0
+sortedcollections

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-# This template is a low-dependency template. 
-# By default there is no requirements added here.
-# Add the requirements you need to this file.
-# or run `make init` to create this file automatically based on the template.
-# You can also run `make switch-to-poetry` to use the poetry package manager.
+sortedcollections==2.4.0

--- a/tests/test_logger_reporter.py
+++ b/tests/test_logger_reporter.py
@@ -36,9 +36,6 @@ def test_logger_reporter():
     last_log_call = logger.debug.call_args_list[-1]
     msg = last_log_call.args[0]
     assert "Call counts: do_nothing: 5 |" in msg
-    assert "Max exec times: do_nothing: " in msg
-    assert "Total exec times: do_nothing: " in msg
-    assert "Avg exec times: do_nothing: " in msg
 
     assert re.search(r"Max exec times: do_nothing: \d+ ", msg, re.MULTILINE)
     assert re.search(r"Total exec times: do_nothing: \d+ ", msg, re.MULTILINE)

--- a/tests/test_logger_reporter.py
+++ b/tests/test_logger_reporter.py
@@ -1,5 +1,6 @@
 import asyncio
 import platform
+import re
 import time
 from unittest import mock
 
@@ -34,7 +35,16 @@ def test_logger_reporter():
     assert logger.debug.call_count >= 1
     last_log_call = logger.debug.call_args_list[-1]
     msg = last_log_call.args[0]
-    assert "'do_nothing': 5" in msg
+    assert "Call counts: do_nothing: 5 |" in msg
+    assert "Max exec times: do_nothing: " in msg
+    assert "Total exec times: do_nothing: " in msg
+    assert "Avg exec times: do_nothing: " in msg
+
+    assert re.search(r"Max exec times: do_nothing: \d+ ", msg, re.MULTILINE)
+    assert re.search(r"Total exec times: do_nothing: \d+ ", msg, re.MULTILINE)
+    assert re.search(
+        r"Avg exec times: do_nothing: \d+(\.\d+)? ", msg, re.MULTILINE
+    )
 
     if platform.system() == "Windows":
         assert "Queue size: 1\n" in msg


### PR DESCRIPTION
- Saving the metrics sorted
- Adding "avg time" metric
- On LoggerReporter, showing the top-5 of each indicator